### PR TITLE
Remove default provider feature

### DIFF
--- a/lib/ipmeta.c
+++ b/lib/ipmeta.c
@@ -90,8 +90,7 @@ void ipmeta_free(ipmeta_t *ipmeta)
 }
 
 int ipmeta_enable_provider(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
-                           const char *options,
-                           ipmeta_provider_default_t set_default)
+                           const char *options)
 {
   char *local_args = NULL;
   char *process_argv[MAXOPTS];
@@ -99,8 +98,7 @@ int ipmeta_enable_provider(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
   int process_argc = 0;
   int rc;
 
-  ipmeta_log(__func__, "enabling provider (%s)%s", provider->name,
-             set_default == IPMETA_PROVIDER_DEFAULT_YES ? " (default)" : "");
+  ipmeta_log(__func__, "enabling provider (%s)", provider->name);
 
   /* first we need to parse the options */
   if (options != NULL && (len = strlen(options)) > 0) {
@@ -109,8 +107,7 @@ int ipmeta_enable_provider(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
   }
 
   /* we just need to pass this along to the provider framework */
-  rc = ipmeta_provider_init(ipmeta, provider, process_argc, process_argv,
-                            set_default);
+  rc = ipmeta_provider_init(ipmeta, provider, process_argc, process_argv);
 
   if (local_args != NULL) {
     free(local_args);
@@ -118,12 +115,6 @@ int ipmeta_enable_provider(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
 
   ipmeta->all_provmask |= (1 << (provider->id - 1));
   return rc;
-}
-
-ipmeta_provider_t *ipmeta_get_default_provider(ipmeta_t *ipmeta)
-{
-  assert(ipmeta != NULL);
-  return ipmeta->provider_default;
 }
 
 inline ipmeta_provider_t *ipmeta_get_provider_by_id(ipmeta_t *ipmeta,

--- a/lib/ipmeta_provider.c
+++ b/lib/ipmeta_provider.c
@@ -127,8 +127,7 @@ int ipmeta_provider_alloc_all(ipmeta_t *ipmeta)
 }
 
 int ipmeta_provider_init(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
-                         int argc, char **argv,
-                         ipmeta_provider_default_t set_default)
+                         int argc, char **argv)
 {
   assert(ipmeta != NULL);
   assert(provider != NULL);
@@ -147,10 +146,6 @@ int ipmeta_provider_init(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
   /* initialize the record hash */
   provider->all_records = kh_init(ipmeta_rechash);
   provider->ds = ipmeta->datastore;
-
-  if (set_default == IPMETA_PROVIDER_DEFAULT_YES) {
-    ipmeta->provider_default = provider;
-  }
 
   /* now that we have set up the datastructure stuff, ask the provider to
      initialize. this will normally mean that it reads in some database and
@@ -181,11 +176,6 @@ void ipmeta_provider_free(ipmeta_t *ipmeta, ipmeta_provider_t *provider)
 
   /* only free everything if we were enabled */
   if (provider->enabled != 0) {
-    /* ok, lets check if we were the default */
-    if (ipmeta->provider_default == provider) {
-      ipmeta->provider_default = NULL;
-    }
-
     /* ask the provider to free it's own state */
     provider->free(provider);
 

--- a/lib/ipmeta_provider.h
+++ b/lib/ipmeta_provider.h
@@ -189,25 +189,15 @@ int ipmeta_provider_alloc_all(ipmeta_t *ipmeta);
  *
  * @param ipmeta        The ipmeta object to initialize the provider for
  * @param provider_id   The unique ID of the metadata provider
- * @param set_default   Set this provider as the default
  * @return the provider object created, NULL if an error occurred
- *
- * @note Default provider status overrides the requests of previous
- * plugins. Thus, the order in which users request the plugins to be run in can
- * have an effect on plugins which make use of the default provider
- * (e.g. corsaro_report).
  */
 int ipmeta_provider_init(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
-                         int argc, char **argv,
-                         ipmeta_provider_default_t set_default);
+                         int argc, char **argv);
 
 /** Free the given provider object
  *
  * @param ipmeta          The ipmeta object to remove the provider from
  * @param provider        The provider object to free
- *
- * @note if this provider was the default, there will be *no* default provider
- * set after this function returns
  */
 void ipmeta_provider_free(ipmeta_t *ipmeta, ipmeta_provider_t *provider);
 

--- a/lib/libipmeta.h
+++ b/lib/libipmeta.h
@@ -57,7 +57,7 @@ typedef struct ipmeta_record_set ipmeta_record_set_t;
 /** @} */
 
 /**
- * @name Public Data Structures
+ * @name Public Enums
  *
  * @{ */
 
@@ -105,6 +105,13 @@ typedef enum ipmeta_ds_id {
   IPMETA_DS_DEFAULT = IPMETA_DS_PATRICIA,
 
 } ipmeta_ds_id_t;
+
+/** @} */
+
+/**
+ * @name Public Data Structures
+ *
+ * @{ */
 
 /** Structure which contains an IP meta-data record
  *
@@ -188,29 +195,9 @@ typedef struct ipmeta_record {
 
 /** @} */
 
-/**
- * @name Public Enums
- *
- * @{ */
-
-/** Should this provider be set to be the default metadata provider
- * @todo make use of this
- */
-typedef enum ipmeta_provider_default {
-  /** This provider should *not* be the default geolocation result */
-  IPMETA_PROVIDER_DEFAULT_NO = 0,
-
-  /** This provider should be the default geolocation result */
-  IPMETA_PROVIDER_DEFAULT_YES = 1,
-
-} ipmeta_provider_default_t;
-
-/** @} */
-
 /** Initialize a new libipmeta instance
  *
  * @param The name of the data structure to use for storing prefixes.
- *        If NULL, the default data structure is used.
  *
  * @return the ipmeta instance created, NULL if an error occurs
  */
@@ -227,7 +214,6 @@ void ipmeta_free(ipmeta_t *ipmeta);
  * @param ipmeta        The ipmeta object to enable the provider for
  * @param provider      Pointer to the provider to be enabled
  * @param options       Options string to pass to the provider
- * @param set_default   Set this provider as default if non-zero
  * @return 0 if the provider was initialized, -1 if an error occurred
  *
  * Once ipmeta_init is called, ipmeta_enable_provider should be called once for
@@ -240,23 +226,9 @@ void ipmeta_free(ipmeta_t *ipmeta);
  * providers, the ipmeta_get_all_providers function can be used to get a list of
  * all providers and then ipmeta_get_provider_name can be used on each to get
  * their name.
- *
- * @note Default provider status overrides the requests of previous
- * plugins. Thus, the order in which users request the plugins to be run in can
- * have an effect on plugins which make use of the default provider
- * (e.g. corsaro_report).
  */
 int ipmeta_enable_provider(ipmeta_t *ipmeta, ipmeta_provider_t *provider,
-                           const char *options,
-                           ipmeta_provider_default_t set_default);
-
-/** Retrieve the provider object for the default metadata provider
- *
- * @param ipmeta       The ipmeta object to retrieve the provider object from
- * @return the provider object for the default provider, NULL if there is no
- * default provider
- */
-ipmeta_provider_t *ipmeta_get_default_provider(ipmeta_t *ipmeta);
+                           const char *options);
 
 /** Retrieve the provider object for the given provider ID
  *

--- a/lib/libipmeta_int.h
+++ b/lib/libipmeta_int.h
@@ -58,9 +58,6 @@ struct ipmeta {
    */
   struct ipmeta_provider *providers[IPMETA_PROVIDER_MAX];
 
-  /** Default metadata provider */
-  struct ipmeta_provider *provider_default;
-
   struct ipmeta_ds *datastore;
 
   uint32_t all_provmask;

--- a/tools/ipmeta-lookup.c
+++ b/tools/ipmeta-lookup.c
@@ -294,8 +294,7 @@ int main(int argc, char **argv)
       goto quit;
     }
 
-    if (ipmeta_enable_provider(ipmeta, provider, provider_arg_ptr,
-                               IPMETA_PROVIDER_DEFAULT_NO) != 0) {
+    if (ipmeta_enable_provider(ipmeta, provider, provider_arg_ptr) != 0) {
       fprintf(stderr, "ERROR: Could not enable plugin %s\n", providers[i]);
       usage(argv[0]);
       goto quit;


### PR DESCRIPTION
This was a half-baked, never-used idea that was designed for a case
where a libipmeta instance was managed centrally and users could ask for
a "default" provider if they didn't have a preference. This only makes
sense when there are multiple providers that perform the same function
(e.g., geolocation), and doesn't help at all if there is e.g., a
geolocation provider and a pfx2as provider enabled. Since this was never
used, it just adds unncessary complexity to the interface.