### PR TITLE
Fix dependency for development package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libipmeta2 (2.1.0-1) unstable; urgency=medium
+
+  * Fix wandio dependency for libipmeta-dev package
+
+ -- Alistair King <software@caida.org>  Thu, 03 Oct 2019 07:30:27 -0700
+
 libipmeta2 (2.1.0) unstable; urgency=medium
 
   * This release removes the concept of "default" providers. This results in a

--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,8 @@ Description: High-performance library for performing IP-metadata tagging
 Package: libipmeta2-dev
 Architecture: any
 Section: libdevel
-Depends: libipmeta2 (=${binary:Version}), ${misc:Depends}
+Depends: libipmeta2 (=${binary:Version}), libwandio1-dev (>=4.2.0),
+ ${misc:Depends}
 Description: Development environment for libipmeta2
  libIPMeta: High-performance library for performing IP-metadata tagging.
  Includes support for Maxmind and Net Acuity geolocation as well as


### PR DESCRIPTION
Since `libipmeta.h` includes `wandio.h` the libipmeta dev package needs to have the libwandio dev packages.