### PR TITLE
Fix debian package build-time dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libipmeta2 (2.1.0-2) unstable; urgency=medium
+
+  * Fix wandio build dependency
+
+ -- Alistair King <software@caida.org>  Thu, 03 Oct 2019 08:05:23 -0700
+
 libipmeta2 (2.1.0-1) unstable; urgency=medium
 
   * Fix wandio dependency for libipmeta-dev package

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: optional
 Maintainer: CAIDA Software Maintainer <software@caida.org>
 Build-Depends: debhelper (>= 10), autotools-dev,
- libwandio1 (>=4.2.0)
+ libwandio1-dev (>=4.2.0)
 Standards-Version: 4.1.2
 Homepage: https://github.com/CAIDA/libipmeta
 


### PR DESCRIPTION
We actually need libwandio1-dev at build time, not just libwandio1.