### PR TITLE
Bump version to 3.1.1 in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,13 +25,13 @@
 AC_PREREQ([2.68])
 
 # Package version should use semantic versioning.
-AC_INIT([libipmeta], [3.1.0], [software@caida.org])
+AC_INIT([libipmeta], [3.1.1], [software@caida.org])
 AM_INIT_AUTOMAKE([foreign])
 
 # Version numbers for the libtool-created library (libipmeta) are unrelated
 # to the overall package version.  For details on Library Versioning, see
 # https://www.sourceware.org/autobook/autobook/autobook_61.html
-LIBIPMETA_LIBTOOL_VERSION=5:0:1
+LIBIPMETA_LIBTOOL_VERSION=5:1:1
 
 LT_INIT
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libipmeta2 (3.1.1-1) unstable; urgency=medium
+
+  * fix bad version number in previous package release
+
+ -- Shane Alcock <software@caida.org>  Mon, 22 Feb 2021 17:19:16 -0700
+
 libipmeta2 (3.1.1) unstable; urgency=medium
 
   * fix bug with large v6 prefixes reporting wrong number of IPs


### PR DESCRIPTION
Update debian changelog version to 3.1.1-1 to trigger a new package build (with hopefully the right version number in the package itself).